### PR TITLE
Enhance HTML parser & update README

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,8 @@
         "no-prototype-builtins": 0
     },
     "globals": {
-      "globalThis": "readonly"
+      "globalThis": "readonly",
+      "MathMLElement": "readonly"
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.0.3] - 2024-03-29
+
+### Added
+- Add support for parsing HTML Documents using `Document.parseHTML()`
+- Add function to parse just a single HTML Element
+- Add support in HTML parser for working with arrays and `NodeList`s, etc
+
+### Changed
+- Update README
+
 ## [Unreleased]
 
 ## [v0.0.2] - 2024-03-28

--- a/html.js
+++ b/html.js
@@ -1,28 +1,5 @@
 import { sanitizer } from '@aegisjsproject/sanitizer/config/base.js';
-
-function stringify(thing) {
-	switch(typeof thing) {
-		case 'string':
-			return thing;
-
-		case 'object':
-			if (thing instanceof DocumentFragment) {
-				return Array.from(
-					thing.childNodes,
-					node => node.nodeType === Node.ELEMENT_NODE
-						? node.outerHTML
-						: node.textContent
-				);
-			} else if (thing instanceof Element) {
-				return thing.outerHTML;
-			} else {
-				return thing.toString();
-			}
-
-		default:
-			return thing.toString();
-	}
-}
+import { stringify } from './utils.js';
 
 export const createHTMLParser = (config = sanitizer) => (strings, ...values) => {
 	const el = document.createElement('div');
@@ -33,3 +10,12 @@ export const createHTMLParser = (config = sanitizer) => (strings, ...values) => 
 };
 
 export const html = createHTMLParser(sanitizer);
+
+export const el = (...args) => html.apply(null, args).firstElementChild;
+
+export function doc(strings, ...values) {
+	return Document.parseHTML(
+		String.raw(strings, ...values.map(stringify)),
+		{ sanitizer }
+	);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/parsers",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/parsers",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/parsers",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A collection of secure & minimal parsers for HTML, CSS, SVG, MathML, XML, and JSON",
   "keywords": [
     "aegis",

--- a/parsers.js
+++ b/parsers.js
@@ -1,4 +1,4 @@
-export { html, createHTMLParser } from './html.js';
+export { html, el, doc, createHTMLParser } from './html.js';
 export { css, createCSSParser, styleSheetToLink, createStyleSheet } from './css.js';
 export { svg } from './svg.js';
 export { math } from './math.js';

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ export default [{
 		'@aegisjsproject/sanitizer/config/svg.js',
 		'@aegisjsproject/sanitizer/config/mathml.js',
 		'@aegisjsproject/sanitizer/config/base.js',
+		'@aegisjsproject/sanitizer/namespaces.js',
 	],
 	output: {
 		file: 'parsers.cjs',

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,34 @@
+const stringifyChildren = thing => Array.from(
+	thing[Symbol.iterator](),
+	node => node.nodeType === Node.ELEMENT_NODE
+		? node.outerHTML
+		: node.textContent
+).join('');
+
+export function stringify(thing) {
+	switch(typeof thing) {
+		case 'string':
+			return thing;
+
+		case 'function':
+			throw new TypeError('Functions are not allowed.');
+
+		case 'object':
+			if (thing === null) {
+				return '';
+			} else if (thing instanceof DocumentFragment || thing instanceof Document) {
+				return stringifyChildren(thing.childNodes);
+			} else if (thing instanceof NodeList || thing instanceof HTMLCollection) {
+				return stringifyChildren(thing);
+			} else if (thing instanceof Element) {
+				return thing.outerHTML;
+			} else if (Array.isArray(thing)) {
+				return thing.map(stringify).join('');
+			} else {
+				return thing.toString();
+			}
+
+		default:
+			return thing.toString();
+	}
+}


### PR DESCRIPTION
- Add support for parsing HTML Documents using `Document.parseHTML()`
- Add function to parse just a single HTML Element
- Add support in HTML parser for working with arrays and `NodeList`s,
etc
- Update README

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
