### PR TITLE
Add custom `stringify` for CSS parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.0.11] - 2024-09-29
+
+### Added
+- Custom `stringy` for CSS (including `blob:` URIs for `File`s & `Blob`s)
+
+### Changed
+- CSS parser now uses `replace` instead of `replaceSync` (still works synchronously)
+
 ## [v0.0.10] - 2024-09-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/parsers",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/parsers",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/parsers",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A collection of secure & minimal parsers for HTML, CSS, SVG, MathML, XML, and JSON",
   "keywords": [
     "aegis",

--- a/test/index.html
+++ b/test/index.html
@@ -7,7 +7,8 @@
 		<meta http-equiv="Content-Security-Policy"
 			content="default-src 'none';
 			script-src 'self' https://unpkg.com/@shgysk8zer0/ https://unpkg.com/@aegisjsproject/ 'sha384-kLwKc1h2n3rxgHAQorvtkYZGT+zfan1+nzl0xYlGL0uR6tweMM5ZrOFt3O1nwUtx';
-			style-src blob:;
+			style-src 'self' blob:;
+			img-src 'self' blob:;
 			connect-src 'none';
 			trusted-types empty#html empty#script aegis-sanitizer#html default;
 			require-trusted-types-for 'script';" />
@@ -20,6 +21,7 @@
 				}
 			}
 		</script>
+		<script type="module" defer="" referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha384-LKWrm336s4/gu00z/eKsqTL+2XNm/OMDwX0jtCXgIiF7zQuTD7WlFrDPkNpGx3Iq" src="https://unpkg.com/@shgysk8zer0/polyfills@0.4.2/array.js" fetchpriority="auto"></script>
 		<script type="module" referrerpolicy="no-referrer" src="./index.js"></script>
 	</head>
 	<body></body>

--- a/test/index.js
+++ b/test/index.js
@@ -2,14 +2,29 @@ import { createHTMLParser, css, svg, completeConfig as sanitizer } from '../bund
 
 const html = createHTMLParser(sanitizer);
 const file = new File(['Thanks for downloading my file :)'], 'thanks.txt', { type: 'text/plain' });
+const styles = await new CSSStyleSheet().replace('#header { display: none; }');
 
 const icon = svg`<svg xmlns="http://www.w3.org/2000/svg" width="12" height="16" viewBox="0 0 12 16" fill="currentColor" role="presentation" aria-label="Close Popover">
 	<path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/>
 </svg>`;
 
-document.adoptedStyleSheets [css`:root {
+const bg = new Blob([`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+	<rect fill="#${crypto.getRandomValues(new Uint8Array(3)).toHex()}" x="0" y="0" width="10" height="10" rx="1" ry="1"></rect>
+</svg>`], { type: 'image/svg+xml' });
+
+document.adoptedStyleSheets = [css`:root {
 	font-family: system-ui;
+	}
+
+body {
+	background-image: url(${bg});
+	background-size: contain;
+	background-position: center;
+	background-repeat: no-repeat;
+	min-height: 100dvh;
 }
+
+${styles.cssRules.item(0)}
 
 #nav {
 	display: flex;
@@ -36,7 +51,8 @@ document.body.append(html`<style>
 	<a href="javascript:alert('javascript:')"><code>javascript:</code> Link</a>
 	<a href="data:text/plain,Not%20Allowed" target="_blank"><code>data:</code> Link</a>
 	<a href="file:${import.meta.url}"><code>file:</code> Link</a>
-	<a href="${URL.createObjectURL(file)}" download="${file.name}" target="_blank"><code>blob:</code> Download Link</a>
+	<a href="${file}" download="${file.name}" target="_blank"><code>blob:</code> Download Link</a>
+	<span>${await file.bytes()}</span>
 </nav>
 <main id="main"></main>
 <div popover="auto" id="bacon">

--- a/utils.js
+++ b/utils.js
@@ -33,6 +33,8 @@ export function stringify(thing) {
 				return new Uint8Array(thing).toBase64();
 			} else if (ArrayBuffer.isView(thing) && thing.toBase64 instanceof Function) {
 				return thing.toBase64();
+			} else if (thing instanceof Blob) {
+				return URL.createObjectURL(thing);
 			} else {
 				return thing.toString();
 			}


### PR DESCRIPTION
- Custom `stringy` for CSS (including `blob:` URIs for `File`s & `Blob`s)

- CSS parser now uses `replace` instead of `replaceSync` (still works synchronously)

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
