### PR TITLE
Add unsafe versions of `html` & `doc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.0.15] - 2024-11-09
+
+### Added
+- Add unsafe versions of `html` and `doc` using `setHTMLUnsafe` and `parseHTMLUnsafe`
+
 ## [v0.0.14] - 2024-11-06
 
 ### Changed

--- a/html.js
+++ b/html.js
@@ -4,15 +4,29 @@ import { stringify } from './utils.js';
 export function createHTMLParser(config = sanitizer, { mapper = stringify } = {}) {
 	return (strings, ...values) => {
 		const frag = document.createDocumentFragment();
-		frag.setHTML(String.raw(strings, ...values.map(mapper)).trim(), config);
+		const tmp = document.createElement('div');
+		tmp.setHTML(String.raw(strings, ...values.map(mapper)).trim(), config);
+		frag.append(...tmp.childNodes);
 		return frag;
 	};
 }
 
 export const html = createHTMLParser(sanitizer, { mapper: stringify });
 
+export function htmlUnsafe(strings, ...values) {
+	const frag = document.createDocumentFragment();
+	const tmp = document.createElement('div');
+	tmp.setHTMLUnsafe(String.raw(strings, ...values.map(stringify)).trim());
+	frag.append(...tmp.childNodes);
+	return frag;
+}
+
 export const el = (...args) => html.apply(null, args).firstElementChild;
 
 export function doc(strings, ...values) {
 	return Document.parseHTML(String.raw(strings, ...values.map(stringify)), sanitizer);
+}
+
+export function docUnsafe(strings, ...values) {
+	return Document.parseHTMLUnsafe(String.raw(strings, ...values.map(stringify)));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/parsers",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/parsers",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/parsers",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "A collection of secure & minimal parsers for HTML, CSS, SVG, MathML, XML, and JSON",
   "keywords": [
     "aegis",

--- a/test/index.js
+++ b/test/index.js
@@ -56,10 +56,12 @@ document.body.append(html`<style>
 </nav>
 <main id="main"></main>
 <div popover="auto" id="bacon">
-	<template shadowrootmode="open">
-		<slot name="close">x</slot>
-		<b>Bacon Ipsum</b>
-		<slot name="content">No Content</slot>
+	<template shadowrootmode="open" shadowrootserializable="">
+		<div part="container">
+			<slot name="close">x</slot>
+			<b>Bacon Ipsum</b>
+			<slot name="content">No Content</slot>
+		</div>
 	</template>
 	<button type="button" popovertarget="bacon" popovertargetaction="hide" slot="close">
 		${icon}


### PR DESCRIPTION
Add unsafe versions of `html` and `doc` using `setHTMLUnsafe` and `parseHTMLUnsafe`

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
